### PR TITLE
move to jenkins version with getJsonSignatureValidator() method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.609.3</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
   
   <groupId>jp.ikedam.jenkins.plugins</groupId>
@@ -55,16 +55,17 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <dependencies>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>[2.3,]</version>
-    </dependency>
-  </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
 </project>

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
@@ -1,0 +1,45 @@
+package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
+
+import jenkins.util.JSONSignatureValidator;
+import org.apache.tools.ant.filters.StringInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * Adds provided cert to trust anchors when validating update center json
+ *
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ExtendedCertJsonSignValidator extends JSONSignatureValidator {
+    private static final Logger LOGGER = Logger.getLogger(ExtendedCertJsonSignValidator.class.getName());
+
+    private String cert;
+
+    public ExtendedCertJsonSignValidator(String id, String cert) {
+        super(format("Update site with own cert for %s", id));
+        this.cert = cert;
+    }
+
+    @Override
+    protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
+        Set<TrustAnchor> trustAnchors = super.loadTrustAnchors(cf);
+        try (InputStream stream = new StringInputStream(cert)) {
+            Certificate certificate = cf.generateCertificate(stream);
+            trustAnchors.add(new TrustAnchor((X509Certificate) certificate, null));
+        } catch (CertificateException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
+        return trustAnchors;
+    }
+}

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
@@ -172,7 +172,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // duplicate id
         {
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -194,7 +193,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // cannot configure for editable
         {
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -217,7 +215,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             editSiteForm = editSitePage.getFormByName("editSiteForm");
             
             assertEquals("no button must exists", 0, editSiteForm.getHtmlElementsByTagName("button").size());
-            assertEquals("no button must exists", 0, editSiteForm.getSubmitButtons().size());
             
             target.setEditable(true);
         }
@@ -314,7 +311,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             int initialSize = Jenkins.getInstance().getUpdateCenter().getSites().size();
             
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage deleteSitePage = wc.goTo(String.format("%s/%s/delete", UpdateSitesManager.URL, target.getPageUrl()));
             assertEquals("UpdateSite must not be deleted yet.", initialSize, Jenkins.getInstance().getUpdateCenter().getSites().size());
@@ -362,7 +358,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
-        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         // configure

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
@@ -23,6 +23,7 @@
  */
 package jp.ikedam.jenkins.plugins.updatesitesmanager;
 
+import com.gargoylesoftware.htmlunit.html.DomElement;
 import hudson.model.Describable;
 import hudson.model.UpdateSite;
 import hudson.model.Descriptor;
@@ -76,7 +77,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         WebClient wc = new WebClient();
         
         HtmlPage updateSitesPage = wc.goTo(UpdateSitesManager.URL);
-        HtmlElement table = updateSitesPage.getElementById("update-sites");
+        DomElement table = updateSitesPage.getElementById("update-sites");
         DomNodeList<HtmlElement> trs = table.getElementsByTagName("tr");
         assertEquals(
             "There are entries even when no updatesites available.",
@@ -108,7 +109,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         WebClient wc = new WebClient();
         
         HtmlPage updateSitesPage = wc.goTo(UpdateSitesManager.URL);
-        HtmlElement table = updateSitesPage.getElementById("update-sites");
+        DomElement table = updateSitesPage.getElementById("update-sites");
         DomNodeList<HtmlElement> trs = table.getElementsByTagName("tr");
         assertEquals(
             "Unexpected rows in updatesites list.",
@@ -434,7 +435,6 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         assertTrue("This test must run with more than one UpdateSite Descriptors registered.", 1 < target.getUpdateSiteDescriptorList().size());
         
         WebClient wc = new WebClient();
-        wc.setPrintContentOnFailingStatusCode(false);
         
         // Post without id.
         {
@@ -616,7 +616,6 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
-        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         wcAdmin.goTo(UpdateSitesManager.URL);

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
@@ -1,0 +1,29 @@
+package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ExtendedCertJsonSignValidatorTest {
+
+    @Test
+    public void shouldAddCustomCertToTrustAnchors() throws Exception {
+        String cert = IOUtils.toString(getClass().getClassLoader()
+                .getResourceAsStream("jp/ikedam/jenkins/plugins/updatesitesmanager/" +
+                        "ManagedUpdateSiteJenkinsTest/caCertificate.crt"), Charsets.UTF_8);
+        CertificateFactory cf = CertificateFactory.getInstance("X509");
+
+        Set<TrustAnchor> test = new ExtendedCertJsonSignValidator("test", cert).loadTrustAnchors(cf);
+        assertThat(test, hasSize(1));
+    }
+}


### PR DESCRIPTION
New versions of Jenkins don't work with current implementation of this plugin. They don't call those methods and don't writes certs

( jenkinsci/jenkins@86ea65a )

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/update-sites-manager-plugin/3)
<!-- Reviewable:end -->
