### PR TITLE
[FIXED JENKINS-32376] Supports server-based downloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.596</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.609</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
   
   <groupId>jp.ikedam.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.609.3</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
   
   <groupId>jp.ikedam.jenkins.plugins</groupId>
@@ -55,16 +55,17 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <dependencies>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>[2.3,]</version>
-    </dependency>
-  </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609.3</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.596</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
   
   <groupId>jp.ikedam.jenkins.plugins</groupId>
@@ -55,17 +55,4 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    
 </project>

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
@@ -1,0 +1,45 @@
+package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
+
+import jenkins.util.JSONSignatureValidator;
+import org.apache.tools.ant.filters.StringInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * Adds provided cert to trust anchors when validating update center json
+ *
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ExtendedCertJsonSignValidator extends JSONSignatureValidator {
+    private static final Logger LOGGER = Logger.getLogger(ExtendedCertJsonSignValidator.class.getName());
+
+    private String cert;
+
+    public ExtendedCertJsonSignValidator(String id, String cert) {
+        super(format("Update site with own cert for %s", id));
+        this.cert = cert;
+    }
+
+    @Override
+    protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
+        Set<TrustAnchor> trustAnchors = super.loadTrustAnchors(cf);
+        try (InputStream stream = new StringInputStream(cert)) {
+            Certificate certificate = cf.generateCertificate(stream);
+            trustAnchors.add(new TrustAnchor((X509Certificate) certificate, null));
+        } catch (CertificateException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
+        return trustAnchors;
+    }
+}

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidator.java
@@ -34,11 +34,18 @@ public class ExtendedCertJsonSignValidator extends JSONSignatureValidator {
     @Override
     protected Set<TrustAnchor> loadTrustAnchors(CertificateFactory cf) throws IOException {
         Set<TrustAnchor> trustAnchors = super.loadTrustAnchors(cf);
-        try (InputStream stream = new StringInputStream(cert)) {
+        InputStream stream = null;
+        try {
+            stream = new StringInputStream(cert);
             Certificate certificate = cf.generateCertificate(stream);
             trustAnchors.add(new TrustAnchor((X509Certificate) certificate, null));
         } catch (CertificateException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } finally {
+            if (stream != null) {
+                stream.close();
+                stream = null;
+            }
         }
         return trustAnchors;
     }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
@@ -172,7 +172,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // duplicate id
         {
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -194,7 +193,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // cannot configure for editable
         {
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -217,7 +215,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             editSiteForm = editSitePage.getFormByName("editSiteForm");
             
             assertEquals("no button must exists", 0, editSiteForm.getHtmlElementsByTagName("button").size());
-            assertEquals("no button must exists", 0, editSiteForm.getSubmitButtons().size());
             
             target.setEditable(true);
         }
@@ -314,7 +311,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             int initialSize = Jenkins.getInstance().getUpdateCenter().getSites().size();
             
             WebClient wc = new WebClient();
-            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage deleteSitePage = wc.goTo(String.format("%s/%s/delete", UpdateSitesManager.URL, target.getPageUrl()));
             assertEquals("UpdateSite must not be deleted yet.", initialSize, Jenkins.getInstance().getUpdateCenter().getSites().size());
@@ -362,7 +358,6 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
-        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         // configure

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
@@ -172,6 +172,7 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // duplicate id
         {
             WebClient wc = new WebClient();
+            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -193,6 +194,7 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         // cannot configure for editable
         {
             WebClient wc = new WebClient();
+            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage editSitePage = wc.goTo(String.format("%s/%s", UpdateSitesManager.URL, target.getPageUrl()));
             
@@ -215,6 +217,7 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             editSiteForm = editSitePage.getFormByName("editSiteForm");
             
             assertEquals("no button must exists", 0, editSiteForm.getHtmlElementsByTagName("button").size());
+            assertEquals("no button must exists", 0, editSiteForm.getSubmitButtons().size());
             
             target.setEditable(true);
         }
@@ -311,6 +314,7 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
             int initialSize = Jenkins.getInstance().getUpdateCenter().getSites().size();
             
             WebClient wc = new WebClient();
+            wc.setPrintContentOnFailingStatusCode(false);
             
             HtmlPage deleteSitePage = wc.goTo(String.format("%s/%s/delete", UpdateSitesManager.URL, target.getPageUrl()));
             assertEquals("UpdateSite must not be deleted yet.", initialSize, Jenkins.getInstance().getUpdateCenter().getSites().size());
@@ -358,6 +362,7 @@ public class DescribedUpdateSiteJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
+        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         // configure

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -33,12 +33,22 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import jenkins.model.DownloadSettings;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.hudson.test.HudsonTestCase;
+import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
+import org.mortbay.jetty.HttpConnection;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.bio.SocketConnector;
+import org.mortbay.jetty.handler.AbstractHandler;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.WebRequestSettings;
@@ -48,6 +58,17 @@ import com.gargoylesoftware.htmlunit.WebRequestSettings;
  */
 public class ManagedUpdateSiteJenkinsTest extends HudsonTestCase
 {
+    private Server server;
+    private URL baseUrl;
+    
+    @Override
+    protected void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+        super.tearDown();
+    }
+    
     static public class TestManagedUpdateSite extends ManagedUpdateSite
     {
         private static final long serialVersionUID = -6888318503867286760L;
@@ -104,9 +125,14 @@ public class ManagedUpdateSiteJenkinsTest extends HudsonTestCase
         // CrumbIssuer causes failures in POST request.
         // I don't know why CrumbIssuer is enabled in a test environment...
         CrumbIssuer crumb = Jenkins.getInstance().getCrumbIssuer();
+        
+        // Jenkins >= 1.600 defaults to use server-based download.
+        // Ensure to use client-based download.
+        boolean isUseBrowser = DownloadSettings.get().isUseBrowser();
         try
         {
             Jenkins.getInstance().setCrumbIssuer(null);
+            DownloadSettings.get().setUseBrowser(true);
             String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt"));
             
             TestManagedUpdateSite target = new TestManagedUpdateSite(
@@ -167,7 +193,102 @@ public class ManagedUpdateSiteJenkinsTest extends HudsonTestCase
         }
         finally
         {
+            DownloadSettings.get().setUseBrowser(isUseBrowser);
             Jenkins.getInstance().setCrumbIssuer(crumb);
+        }
+    }
+    
+    public void setUpWebServer() throws Exception {
+        server = new Server();
+        SocketConnector connector = new SocketConnector();
+        server.addConnector(connector);
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(
+                String target, HttpServletRequest request,
+                HttpServletResponse response, int dispatch
+            ) throws IOException, ServletException
+            {
+                String responseBody = null;
+                try {
+                    responseBody = FileUtils.readFileToString(getResource(target), "UTF-8");
+                } catch(URISyntaxException e) {
+                    HttpConnection.getCurrentConnection().getRequest().setHandled(true);
+                    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                }
+                if (responseBody != null) {
+                    HttpConnection.getCurrentConnection().getRequest().setHandled(true);
+                    response.setContentType("text/plain; charset=utf-8");
+                    response.setStatus(HttpServletResponse.SC_OK);
+                    response.getOutputStream().write(responseBody.getBytes());
+                }
+            }
+        });
+        server.start();
+        baseUrl = new URL("http", "localhost", connector.getLocalPort(), "");
+    }
+    
+    public void testDoCheckUpdateServer() throws Exception {
+        setUpWebServer();
+        
+        // Ensure to use server-based download.
+        boolean isUseBrowser = DownloadSettings.get().isUseBrowser();
+        try
+        {
+            DownloadSettings.get().setUseBrowser(false);
+            String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt"));
+            
+            TestManagedUpdateSite target = new TestManagedUpdateSite(
+                    "test",
+                    new URL(baseUrl, "update-center.json").toExternalForm(),
+                    false,
+                    null,
+                    "test",
+                    false
+            );
+            jenkins.getUpdateCenter().getSites().clear();
+            jenkins.getUpdateCenter().getSites().add(target);
+            jenkins.getUpdateCenter().save();
+            
+            {
+                target.setCaCertificate(null);
+                HttpResponse rsp = jenkins.getPluginManager().doCheckUpdatesServer();
+                if (rsp instanceof FormValidation) {
+                    assertEquals(
+                            "Accessing update center with no certificate must fail",
+                            FormValidation.Kind.ERROR,
+                            ((FormValidation)rsp).kind
+                    );
+                }
+            }
+            
+            {
+                target.setCaCertificate(caCertificate);
+                HttpResponse rsp = jenkins.getPluginManager().doCheckUpdatesServer();
+                if (rsp instanceof FormValidation) {
+                    assertEquals(
+                            "Accessing update center with a proper certificate must succeed",
+                            FormValidation.Kind.OK,
+                            ((FormValidation)rsp).kind
+                    );
+                }
+            }
+            
+            {
+                target.setCaCertificate(null);
+                HttpResponse rsp = jenkins.getPluginManager().doCheckUpdatesServer();
+                if (rsp instanceof FormValidation) {
+                    assertEquals(
+                            "Accessing update center with no certificate must fail",
+                            FormValidation.Kind.ERROR,
+                            ((FormValidation)rsp).kind
+                    );
+                }
+            }
+        }
+        finally
+        {
+            DownloadSettings.get().setUseBrowser(isUseBrowser);
         }
     }
     

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -247,8 +247,21 @@ public class ManagedUpdateSiteJenkinsTest extends HudsonTestCase
                     false
             );
             jenkins.getUpdateCenter().getSites().clear();
+            
+            {
+                target.setCaCertificate(null);
+                HttpResponse rsp = jenkins.getPluginManager().doCheckUpdatesServer();
+                if (rsp instanceof FormValidation) {
+                    // this fails with Jenkins < 1.600, Jenkins < 1.596.1
+                    assertEquals(
+                            "Accessing update center without any update sites should succeed",
+                            FormValidation.Kind.OK,
+                            ((FormValidation)rsp).kind
+                    );
+                }
+            }
+            
             jenkins.getUpdateCenter().getSites().add(target);
-            jenkins.getUpdateCenter().save();
             
             {
                 target.setCaCertificate(null);

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -23,6 +23,7 @@
  */
 package jp.ikedam.jenkins.plugins.updatesitesmanager;
 
+import hudson.security.csrf.CrumbIssuer;
 import hudson.util.FormValidation;
 
 import java.io.File;
@@ -32,11 +33,15 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 
+import jenkins.model.Jenkins;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.kohsuke.stapler.StaplerRequest;
+
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequestSettings;
 
 /**
  * Tests for ManagedUpdateSite, concerned with Jenkins.
@@ -92,6 +97,78 @@ public class ManagedUpdateSiteJenkinsTest extends HudsonTestCase
             throw new FileNotFoundException(String.format("Not found: %s", filename));
         }
         return new File(url.toURI());
+    }
+    
+    public void testDoPostBack() throws URISyntaxException, IOException, GeneralSecurityException
+    {
+        // CrumbIssuer causes failures in POST request.
+        // I don't know why CrumbIssuer is enabled in a test environment...
+        CrumbIssuer crumb = Jenkins.getInstance().getCrumbIssuer();
+        try
+        {
+            Jenkins.getInstance().setCrumbIssuer(null);
+            String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt"));
+            
+            TestManagedUpdateSite target = new TestManagedUpdateSite(
+                    "test",
+                    "http://localhost/update-center.json",
+                    false,
+                    null,
+                    "test",
+                    false
+            );
+            Jenkins.getInstance().getUpdateCenter().getSites().clear();
+            Jenkins.getInstance().getUpdateCenter().getSites().add(target);
+            Jenkins.getInstance().getUpdateCenter().save();
+            
+            WebClient wc = new WebClient();
+            WebRequestSettings wrs = new WebRequestSettings(
+                    new URL(String.format("%s%s/byId/%s/postBack",
+                            wc.getContextPath(),
+                            Jenkins.getInstance().getUpdateCenter().getSearchUrl(),
+                            target.getId()
+                    )),
+                    HttpMethod.POST
+            );
+            wrs.setAdditionalHeader("Content-Type", "application/json; charset=UTF-8");
+            wrs.setRequestBody(FileUtils.readFileToString(getResource("update-center.json"), "UTF-8"));
+            
+            {
+                target.setDoPostBackResult(null);
+                wc.getPage(wrs);
+                assertEquals(
+                        "Accessing update center with no certificate must fail",
+                        FormValidation.Kind.ERROR,
+                        target.getDoPostBackResult().kind
+                );
+            }
+            
+            {
+                target.setCaCertificate(caCertificate);
+                target.setDoPostBackResult(null);
+                wc.getPage(wrs);
+                assertEquals(
+                        "Accessing update center with a proper certificate must succeed",
+                        FormValidation.Kind.OK,
+                        target.getDoPostBackResult().kind
+                );
+            }
+            
+            {
+                target.setCaCertificate(null);
+                target.setDoPostBackResult(null);
+                wc.getPage(wrs);
+                assertEquals(
+                        "Accessing update center with no certificate must fail",
+                        FormValidation.Kind.ERROR,
+                        target.getDoPostBackResult().kind
+                );
+            }
+        }
+        finally
+        {
+            Jenkins.getInstance().setCrumbIssuer(crumb);
+        }
     }
     
     private ManagedUpdateSite.DescriptorImpl getDescriptor()

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
@@ -435,6 +435,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         assertTrue("This test must run with more than one UpdateSite Descriptors registered.", 1 < target.getUpdateSiteDescriptorList().size());
         
         WebClient wc = new WebClient();
+        wc.setPrintContentOnFailingStatusCode(false);
         
         // Post without id.
         {
@@ -616,6 +617,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
+        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         wcAdmin.goTo(UpdateSitesManager.URL);

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
@@ -23,6 +23,7 @@
  */
 package jp.ikedam.jenkins.plugins.updatesitesmanager;
 
+import com.gargoylesoftware.htmlunit.html.DomElement;
 import hudson.model.Describable;
 import hudson.model.UpdateSite;
 import hudson.model.Descriptor;
@@ -76,7 +77,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         WebClient wc = new WebClient();
         
         HtmlPage updateSitesPage = wc.goTo(UpdateSitesManager.URL);
-        HtmlElement table = updateSitesPage.getElementById("update-sites");
+        DomElement table = updateSitesPage.getElementById("update-sites");
         DomNodeList<HtmlElement> trs = table.getElementsByTagName("tr");
         assertEquals(
             "There are entries even when no updatesites available.",
@@ -108,7 +109,7 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         WebClient wc = new WebClient();
         
         HtmlPage updateSitesPage = wc.goTo(UpdateSitesManager.URL);
-        HtmlElement table = updateSitesPage.getElementById("update-sites");
+        DomElement table = updateSitesPage.getElementById("update-sites");
         DomNodeList<HtmlElement> trs = table.getElementsByTagName("tr");
         assertEquals(
             "Unexpected rows in updatesites list.",
@@ -434,7 +435,6 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         assertTrue("This test must run with more than one UpdateSite Descriptors registered.", 1 < target.getUpdateSiteDescriptorList().size());
         
         WebClient wc = new WebClient();
-        wc.setPrintContentOnFailingStatusCode(false);
         
         // Post without id.
         {
@@ -616,7 +616,6 @@ public class UpdateSitesManagerJenkinsTest extends HudsonTestCase
         wcAdmin.login("admin", "admin");
         
         WebClient wcUser = new WebClient();
-        wcUser.setPrintContentOnFailingStatusCode(false);
         wcUser.login("user", "user");
         
         wcAdmin.goTo(UpdateSitesManager.URL);

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
@@ -1,29 +1,38 @@
 package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
 
+import net.sf.json.JSONObject;
+
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-import java.security.cert.CertificateFactory;
-import java.security.cert.TrustAnchor;
-import java.util.Set;
+import hudson.util.FormValidation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import jenkins.util.JSONSignatureValidator;
+import static org.junit.Assert.*;
 
 /**
  * @author lanwen (Merkushev Kirill)
  */
 public class ExtendedCertJsonSignValidatorTest {
 
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
     @Test
     public void shouldAddCustomCertToTrustAnchors() throws Exception {
+        String RESOURCE_BASE = "jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest";
+        
         String cert = IOUtils.toString(getClass().getClassLoader()
-                .getResourceAsStream("jp/ikedam/jenkins/plugins/updatesitesmanager/" +
-                        "ManagedUpdateSiteJenkinsTest/caCertificate.crt"), Charsets.UTF_8);
-        CertificateFactory cf = CertificateFactory.getInstance("X509");
-
-        Set<TrustAnchor> test = new ExtendedCertJsonSignValidator("test", cert).loadTrustAnchors(cf);
-        assertThat(test, hasSize(1));
+                .getResourceAsStream(RESOURCE_BASE + "/caCertificate.crt"), Charsets.UTF_8);
+        JSONSignatureValidator validator = new ExtendedCertJsonSignValidator("test", cert);
+        //JSONSignatureValidator validator = new JSONSignatureValidator("test");
+        JSONObject ucToTest = JSONObject.fromObject(IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream(RESOURCE_BASE + "/update-center.json"),
+                Charsets.UTF_8
+        ));
+        assertEquals(FormValidation.Kind.OK, validator.verifySignature(ucToTest).kind);
     }
 }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
@@ -1,0 +1,29 @@
+package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
+
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ */
+public class ExtendedCertJsonSignValidatorTest {
+
+    @Test
+    public void shouldAddCustomCertToTrustAnchors() throws Exception {
+        String cert = IOUtils.toString(getClass().getClassLoader()
+                .getResourceAsStream("jp/ikedam/jenkins/plugins/updatesitesmanager/" +
+                        "ManagedUpdateSiteJenkinsTest/caCertificate.crt"), Charsets.UTF_8);
+        CertificateFactory cf = CertificateFactory.getInstance("X509");
+
+        Set<TrustAnchor> test = new ExtendedCertJsonSignValidator("test", cert).loadTrustAnchors(cf);
+        assertThat(test, hasSize(1));
+    }
+}


### PR DESCRIPTION
[JENKINS-32376](https://issues.jenkins-ci.org/browse/JENKINS-32376)

Additional changes to #3.

* Changed to the target version 1.609. (was 1.609.3)
    * Though this change should work even with 1.596, server-based downloading looks have critical issues  since 1.600 (`Downloadable` refers URLs that doesn't contain signatures).
    * I decided not to support server-based downloading with Jenkins 1.557 - 1.608 (including 1.565.x, 1.580.x, 1.596.x).
        * server-based downloading is enabled by default since 1.600.
    * I prefer to use the baseline of LTS.
* Reverted removed tests.
    * Those tests still work with Jenkins 1.609.
    * Methods that doesn't work with the latest htmlunit can be replace with other methods and tests doesn't need to be removed (`WebClient#setPrintContentOnFailingStatusCode` -> `WebClientOptions#setPrintContentOnFailingStatusCode`, `WebRequestSetting` -> `WebRequest`).
        * This changes are required with Jenkins >= 1.627.
* Make work with Java 6.
    * Jenkins 1.609 still supports Java 6 (Jenkins >= 1.615 supports only Java7).
    * Though I agree try-with-resources is useful, I decided to rewrite that in Java6 compatible way as it can be done with almost no risks. 
* Added an integration test for server-based behavior to ensure that certification checks work.
    * This fails with Jenkins < 1.600 as `Downloadable
* `ExtendedCertJsonSignValidatorTest#shouldAddCustomCertToTrustAnchors` is rewritten.
    * Now launches Jenkins instance (with `JenkinsRule`) and tests integration with Jenkins and asserts that the signature check is performed as expected.