### PR TITLE
Removed Serializable

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
@@ -32,7 +32,6 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -41,8 +40,7 @@ import java.util.List;
 /**
  * Base for UpdateSite that have Descriptor.
  */
-@SuppressWarnings("serial")
-abstract public class DescribedUpdateSite extends UpdateSite implements Describable<DescribedUpdateSite>, ExtensionPoint, Serializable
+abstract public class DescribedUpdateSite extends UpdateSite implements Describable<DescribedUpdateSite>, ExtensionPoint
 {
     /**
      * Constructor

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
@@ -55,8 +55,6 @@ import javax.annotation.Nonnull;
  */
 public class ManagedUpdateSite extends DescribedUpdateSite
 {
-    private static final long serialVersionUID = -714713790690982048L;
-    
     private static Logger LOGGER = Logger.getLogger(ManagedUpdateSite.class.getName());
     
     private String caCertificate;

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
@@ -53,9 +53,6 @@ public class DescribedUpdateSiteJenkinsTest {
     public ExpectedException ex = ExpectedException.none();
 
     public static class DescribedUpdateSiteForConfigureTest extends DescribedUpdateSite {
-        private static final long serialVersionUID = -5159897288105253315L;
-
-
         private String testValue;
 
         public String getTestValue() {

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteSimpleTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteSimpleTest.java
@@ -40,8 +40,6 @@ import static org.hamcrest.Matchers.is;
 @RunWith(DataProviderRunner.class)
 public class DescribedUpdateSiteSimpleTest {
     private static class TestDescribedUpdateSite extends DescribedUpdateSite {
-        private static final long serialVersionUID = 1934091438438690698L;
-
         public TestDescribedUpdateSite(String id, String url) {
             super(id, url);
         }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -148,8 +148,6 @@ public class ManagedUpdateSiteJenkinsTest {
     }
 
     static public class TestManagedUpdateSite extends ManagedUpdateSite {
-        private static final long serialVersionUID = -6888318503867286760L;
-
         public TestManagedUpdateSite(
                 String id,
                 String url,


### PR DESCRIPTION
Objects are serialized with [Xstream](http://x-stream.github.io/), and doesn't require `Serializable`.
I don't preserve binary compatibilities in the next release and decided to remove `Serializable` taking this opportunity.

