### PR TITLE
Removed DescribedUpdateSite.Descriptor#canCreateNewSite.

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
@@ -190,18 +190,6 @@ abstract public class DescribedUpdateSite extends UpdateSite implements Describa
         abstract public String getDescription();
         
         /**
-         * Returns whether this DescribedUpdateSite can be used to create a new UpdateSite.
-         * 
-         * Return false for classes that is used for managing existing entry, but not for add new entry.
-         * 
-         * @return whether this DescribedUpdateSite can be used to create a new UpdateSite.
-         */
-        public boolean canCreateNewSite()
-        {
-            return true;
-        }
-        
-        /**
          * Validate id
          * 
          * @param id

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManager.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManager.java
@@ -133,15 +133,10 @@ public class UpdateSitesManager extends ManagementLink {
     /**
      * Returns all the registered DescribedUpdateSite.
      *
-     * Only returns DescribedUpdateSite that can be used to create a new site.
-     *
      * @return a list of Desctiptor of DescribedUpdateSite.
      */
     public List<DescribedUpdateSite.Descriptor> getUpdateSiteDescriptorList() {
-        return newArrayList(Iterables.filter(
-                DescribedUpdateSite.all(),
-                new CanCreateNewSiteFilter()
-        ));
+        return DescribedUpdateSite.all();
     }
 
     /**
@@ -212,16 +207,6 @@ public class UpdateSitesManager extends ManagementLink {
         public boolean apply(UpdateSite input) {
             return StringUtils.isBlank(input.getId());
 
-        }
-    }
-
-    /**
-     * Should show only descriptors with ability to create new sites
-     */
-    public static class CanCreateNewSiteFilter implements Predicate<DescribedUpdateSite.Descriptor> {
-        @Override
-        public boolean apply(DescribedUpdateSite.Descriptor descriptor) {
-            return descriptor.canCreateNewSite();
         }
     }
 }


### PR DESCRIPTION
It's originally introduced so that other plugins can define its own update sites.
However, I don't think it is actually useful for those plugins (e.g. administrators can remove that site).
Anyway, there looks no plugin depending on this feature.

I remove this feature here, and will consider to redesign an alternate feature if someone requires this feature.

