### PR TITLE
No signature check option

### DIFF
--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import jenkins.util.JSONSignatureValidator;
+import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.ExtendedCertJsonSignValidator;
 import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.NoCertJsonSignValidator;
 
 import org.apache.commons.lang.StringUtils;
@@ -92,6 +93,18 @@ public class ManagedUpdateSite extends DescribedUpdateSite
         return getCaCertificate() != null;
     }
     
+    private boolean skipSignatureCheck;
+    
+    /**
+     * Returns whether to skip signature checks
+     * 
+     * @return whether to skip signature checks
+     */
+    public boolean isSkipSignatureCheck()
+    {
+        return skipSignatureCheck;
+    }    
+    
     private boolean disabled;
     
     /**
@@ -139,13 +152,16 @@ public class ManagedUpdateSite extends DescribedUpdateSite
             boolean useCaCertificate,
             String caCertificate,
             String note,
-            boolean disabled
+            boolean disabled,
+            boolean skipSignatureCheck
+            
     )
     {
         super(id, url);
         this.caCertificate = useCaCertificate?StringUtils.trim(caCertificate):null;
         this.note = note;
         this.disabled = disabled;
+        this.skipSignatureCheck = skipSignatureCheck;
     }
     
     /**
@@ -157,12 +173,13 @@ public class ManagedUpdateSite extends DescribedUpdateSite
     @Override
     protected JSONSignatureValidator getJsonSignatureValidator()
     {
-        return new NoCertJsonSignValidator(getId(), getCaCertificate());
-        /*if (isUseCaCertificate()) {
+        if(isSkipSignatureCheck()) {
+          return new NoCertJsonSignValidator(getId(), getCaCertificate());
+        } else if (isUseCaCertificate()) {
             return new ExtendedCertJsonSignValidator(getId(), getCaCertificate());
         } else {
             return super.getJsonSignatureValidator();
-        }*/
+        }
     }
     
     /**

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite.java
@@ -23,6 +23,9 @@
  */
 package jp.ikedam.jenkins.plugins.updatesitesmanager;
 
+import hudson.Extension;
+import hudson.util.FormValidation;
+
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.cert.CertificateException;
@@ -30,16 +33,14 @@ import java.security.cert.CertificateFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import hudson.Extension;
-import hudson.util.FormValidation;
+import javax.annotation.Nonnull;
 
 import jenkins.util.JSONSignatureValidator;
-import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.ExtendedCertJsonSignValidator;
+import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.NoCertJsonSignValidator;
+
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import javax.annotation.Nonnull;
 
 /**
  * Extended UpdateSite to be managed in UpdateSitesManager.
@@ -156,11 +157,12 @@ public class ManagedUpdateSite extends DescribedUpdateSite
     @Override
     protected JSONSignatureValidator getJsonSignatureValidator()
     {
-        if (isUseCaCertificate()) {
+        return new NoCertJsonSignValidator(getId(), getCaCertificate());
+        /*if (isUseCaCertificate()) {
             return new ExtendedCertJsonSignValidator(getId(), getCaCertificate());
         } else {
             return super.getJsonSignatureValidator();
-        }
+        }*/
     }
     
     /**

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/NoCertJsonSignValidator.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/NoCertJsonSignValidator.java
@@ -1,0 +1,26 @@
+package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
+
+import static java.lang.String.format;
+import hudson.util.FormValidation;
+
+import java.io.IOException;
+
+import jenkins.util.JSONSignatureValidator;
+import net.sf.json.JSONObject;
+
+/**
+ * Skips signature validation
+ */
+public class NoCertJsonSignValidator extends JSONSignatureValidator {
+
+    public NoCertJsonSignValidator(String id, String cert) {
+        super(format("Update site without cert for %s", id));
+    }
+
+    @Override
+    public FormValidation verifySignature(JSONObject arg0) throws IOException
+    {
+      return FormValidation.ok();
+    }
+    
+}

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
@@ -43,4 +43,7 @@ THE SOFTWARE.
         <f:textarea />
       </f:entry>
     </f:optionalBlock>
+    <f:validateButton
+       title="${%Check Connection}" progress="${%Testing...}"
+       method="checkConnection" with="id,url,useCaCertificate,caCertificate,note,disable,skipSignatureCheck" />    
 </j:jelly>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
@@ -35,6 +35,9 @@ THE SOFTWARE.
     <f:entry title="${%Note}" field="note">
         <f:textbox />
     </f:entry>
+    <f:entry title="${%Skip Signature Check}" field="skipSignatureCheck">
+        <f:checkbox />
+    </f:entry>
     <f:optionalBlock field="useCaCertificate" inline="true" title="${%Need CA Certificate}">
       <f:entry title="${%CA Certificate}" field="caCertificate">
         <f:textarea />

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/help-skipSignatureCheck.html
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/help-skipSignatureCheck.html
@@ -1,0 +1,9 @@
+<div>
+  <p>Check when you want to skip the signature check for this update site.
+  This is useful for test or internal update sites not providing a signature.</p>
+  
+  <p>Be aware signature checking is a security feature and disabling it might compromise your Jenkins.<br/>
+  Make sure to <b>disable</b> <code>"Use browser for metadata download"</code> when skipping the signature check (Manage Jenkins > Configure Global Security > Use browser for metadata download)!
+  </p>
+   
+</div>

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -129,7 +129,7 @@ public class ManagedUpdateSiteJenkinsTest {
     }
 
     private ManagedUpdateSite.DescriptorImpl getDescriptor() {
-        return (ManagedUpdateSite.DescriptorImpl) new ManagedUpdateSite(null, null, false, null, null, false)
+        return (ManagedUpdateSite.DescriptorImpl) new ManagedUpdateSite(null, null, false, null, null, false, false)
                 .getDescriptor();
     }
 
@@ -143,7 +143,7 @@ public class ManagedUpdateSiteJenkinsTest {
                 false,
                 null,
                 "test",
-                false
+                false, false
         );
     }
 
@@ -154,9 +154,10 @@ public class ManagedUpdateSiteJenkinsTest {
                 boolean useCaCertificate,
                 String caCertificate,
                 String note,
-                boolean disabled
+                boolean disabled,
+                boolean skipSignatureCheck
         ) {
-            super(id, url, useCaCertificate, caCertificate, note, disabled);
+            super(id, url, useCaCertificate, caCertificate, note, disabled, skipSignatureCheck);
         }
     }
 }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
@@ -90,7 +90,7 @@ public class UpdateSitesManagerJenkinsTest {
                 false,
                 null,
                 null,
-                false
+                false, false
         );
         // Multiple update site.
         jRule.getInstance().getUpdateCenter().getSites().clear();
@@ -129,7 +129,7 @@ public class UpdateSitesManagerJenkinsTest {
     public void shouldSubmitSites() throws Exception {
         UpdateSite site1 = new UpdateSite("test1", "http://example.com/test/update-center.json");
         UpdateSite site2 = new ManagedUpdateSite("test2", "http://example.com/test2/update-center.json",
-                false, null, "", false
+                false, null, "", false, false
         );
         jRule.getInstance().getUpdateCenter().getSites().clear();
         jRule.getInstance().getUpdateCenter().getSites().add(site1);
@@ -152,7 +152,7 @@ public class UpdateSitesManagerJenkinsTest {
     @Test
     public void shouldReturn400OnBlankId() throws Exception {
         UpdateSite site = new ManagedUpdateSite(" ", "http://example.com/test2/update-center.json",
-                false, null, null, false
+                false, null, null, false, false
         );
         jRule.getInstance().getUpdateCenter().getSites().clear();
         jRule.getInstance().getUpdateCenter().getSites().add(site);
@@ -169,7 +169,7 @@ public class UpdateSitesManagerJenkinsTest {
     public void shouldReturn400OnDuplicatedId() throws Exception {
         UpdateSite site1 = new UpdateSite("test1", "http://example.com/test/update-center.json");
         UpdateSite site2 = new ManagedUpdateSite("test1", "http://example.com/test2/update-center.json",
-                false, null, null, false
+                false, null, null, false, false
         );
         jRule.getInstance().getUpdateCenter().getSites().clear();
         jRule.getInstance().getUpdateCenter().getSites().add(site1);


### PR DESCRIPTION
For tests and internal usage we need to be able to disable the signature checks for specific update sites. I implemented it as a configurable option.
Furthermore I added a "check connection" button which is quite useful.