### PR TITLE
Support update sites protected by credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>4.31</version>
   </parent>
   
   <groupId>jp.ikedam.jenkins.plugins</groupId>
@@ -38,8 +38,8 @@
   </licenses>
   
   <properties>
-    <jenkins.version>1.609</jenkins.version>
-    <java.level>6</java.level>
+    <java.level>8</java.level>
+    <jenkins.version>2.303.1</jenkins.version>
   </properties>
   
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
@@ -71,12 +71,40 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1036.v9f5a1aba8fab</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
-    
+
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>2.5</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSite.java
@@ -153,7 +153,7 @@ abstract public class DescribedUpdateSite extends UpdateSite implements Describa
      */
     static public DescriptorExtensionList<DescribedUpdateSite, DescribedUpdateSiteDescriptopr> all()
     {
-        return Jenkins.getActiveInstance().getDescriptorList(DescribedUpdateSite.class);
+        return Jenkins.get().getDescriptorList(DescribedUpdateSite.class);
     }
     
     
@@ -166,6 +166,6 @@ abstract public class DescribedUpdateSite extends UpdateSite implements Describa
     @Override
     public DescribedUpdateSiteDescriptopr getDescriptor()
     {
-        return (DescribedUpdateSiteDescriptopr) Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
+        return (DescribedUpdateSiteDescriptopr) Jenkins.get().getDescriptorOrDie(getClass());
     }
 }

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateCenterConfiguration.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateCenterConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2021 Falco Nikolas
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jp.ikedam.jenkins.plugins.updatesitesmanager;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import hudson.model.UpdateCenter.DownloadJob;
+import hudson.model.UpdateCenter.UpdateCenterConfiguration;
+
+public class ManagedUpdateCenterConfiguration extends UpdateCenterConfiguration {
+
+    private String credentialsId;
+
+    public ManagedUpdateCenterConfiguration(String credentialsId) {
+        this.credentialsId = credentialsId;
+    }
+
+    @Override
+    protected URLConnection connect(DownloadJob job, URL src) throws IOException {
+        URLConnection uc = super.connect(job, src);
+        UpdateSiteManagerHelper.addAuthorisationHeader(uc, credentialsId);
+        return uc;
+    }
+
+}

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSiteManagerHelper.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSiteManagerHelper.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2021 Falco Nikolas
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jp.ikedam.jenkins.plugins.updatesitesmanager;
+
+import java.io.IOException;
+import java.net.URLConnection;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+
+/* package*/ class UpdateSiteManagerHelper {
+
+    @Nullable
+    public static <C extends IdCredentials> C findCredentialsById(String id, @Nonnull Class<C> type) {
+        List<C> credentials = CredentialsProvider.lookupCredentials(type, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
+        return CredentialsMatchers.firstOrNull(credentials, CredentialsMatchers.withId(id));
+    }
+
+    public static void addAuthorisationHeader(URLConnection connection, @Nullable String credentialsId) throws IOException {
+        if (credentialsId == null) {
+            return;
+        }
+
+        StandardUsernamePasswordCredentials credential = UpdateSiteManagerHelper.findCredentialsById(credentialsId, StandardUsernamePasswordCredentials.class);
+        if (credential != null) {
+            String token = credential.getUsername() + ':' + credential.getPassword().getPlainText();
+            String basicAuth = "Basic " + Base64.getEncoder().encodeToString(token.getBytes("UTF-8"));
+            connection.setRequestProperty ("Authorization", basicAuth);
+        } else {
+            throw new IOException(Messages.UpdateSiteManagerHelper_invalidCredentials(credentialsId));
+        }
+    }
+}

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManager.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManager.java
@@ -36,8 +36,6 @@ import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.IgnoreNotPOST;
 import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.OnlyAdminister;
 import jp.ikedam.jenkins.plugins.updatesitesmanager.internal.Sites;
 import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -116,7 +114,7 @@ public class UpdateSitesManager extends ManagementLink {
      */
     public List<UpdateSite> getManagedUpdateSiteList() {
         return newArrayList(Iterables.filter(
-                Jenkins.getActiveInstance().getUpdateCenter().getSites(),
+                Jenkins.get().getUpdateCenter().getSites(),
                 new IsSiteManaged())
         );
     }
@@ -128,7 +126,7 @@ public class UpdateSitesManager extends ManagementLink {
      */
     public List<UpdateSite> getNotManagedUpdateSiteList() {
         return newArrayList(Iterables.filter(
-                Jenkins.getActiveInstance().getUpdateCenter().getSites(),
+                Jenkins.get().getUpdateCenter().getSites(),
                 not(new IsSiteManaged())
         ));
     }
@@ -160,8 +158,8 @@ public class UpdateSitesManager extends ManagementLink {
         shouldNotContainDuplicatedIds(newSitesList);
         shouldNotContainBlankIds(newSitesList);
 
-        Jenkins.getActiveInstance().getUpdateCenter().getSites().replaceBy(newSitesList);
-        Jenkins.getActiveInstance().getUpdateCenter().save();
+        Jenkins.get().getUpdateCenter().getSites().replaceBy(newSitesList);
+        Jenkins.get().getUpdateCenter().save();
 
         FormApply.success(req.getContextPath() + "/manage").generateResponse(req, rsp, null);
     }

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/IgnoreNotPOST.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/IgnoreNotPOST.java
@@ -14,6 +14,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 
+import javax.servlet.ServletException;
+
 /**
  * Just redirects to url of sites manager if not POST
  *
@@ -27,7 +29,7 @@ public @interface IgnoreNotPOST {
     class Processor extends Interceptor {
         @Override
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
-                throws IllegalAccessException, InvocationTargetException {
+                throws IllegalAccessException, InvocationTargetException, ServletException {
 
             if (!request.getMethod().equals("POST")) {
                 throw new InvocationTargetException(HttpResponses.redirectViaContextPath(UpdateSitesManager.URL));

--- a/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/OnlyAdminister.java
+++ b/src/main/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/OnlyAdminister.java
@@ -13,6 +13,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 
+import javax.servlet.ServletException;
+
 /**
  * Returns 403 if not permitted
  *
@@ -26,9 +28,9 @@ public @interface OnlyAdminister {
     class Processor extends Interceptor {
         @Override
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
-                throws IllegalAccessException, InvocationTargetException {
+                throws IllegalAccessException, InvocationTargetException, ServletException {
 
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             return target.invoke(request, response, instance, arguments);
         }
     }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,5 +3,5 @@
 -->
 <?jelly escape-by-default='true'?>
 <div>
-  This plugin is to manage update sites, where Jenkins accesses in order to retrieve plugins.
+  This plugin is to manage update sites under security, where Jenkins accesses in order to retrieve plugins.
 </div>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/config.jelly
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="${%Disable this site}" field="disabled">
         <f:checkbox />
     </f:entry>
@@ -31,6 +31,9 @@ THE SOFTWARE.
     </f:entry>
     <f:entry title="${%URL}" field="url">
         <f:textbox />
+    </f:entry>
+    <f:entry title="${%Credentials}" field="credentialsId">
+        <c:select />
     </f:entry>
     <f:entry title="${%Note}" field="note">
         <f:textbox />

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/help-credentialsId.html
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSite/help-credentialsId.html
@@ -1,0 +1,3 @@
+<div>
+  The credentials to use to download plugins from the update site.
+</div>

--- a/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/Messages.properties
+++ b/src/main/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/Messages.properties
@@ -6,3 +6,4 @@ DescribedupdateSite.url.invalid=Invalid URL: {0}
 ManagedUpdateSite.DisplayName=Update Site
 ManagedUpdateSite.caCertificate.required=Required
 ManagedUpdateSite.caCertificate.invalid=Invalid Certificate: {0}
+UpdateSiteManagerHelper.invalidCredentials=Credentials {0} not found. The connection will be done as anonymous.

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -26,7 +26,6 @@ package jp.ikedam.jenkins.plugins.updatesitesmanager;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import hudson.util.FormValidation;
-import jenkins.model.DownloadSettings;
 import jp.ikedam.jenkins.plugins.updatesitesmanager.testext.WebServerRecipe;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
@@ -61,7 +60,7 @@ public class ManagedUpdateSiteJenkinsTest {
 
     @Test
     public void testDescriptorDoCheckCaCertificate() throws IOException, URISyntaxException {
-        String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt", getClass()));
+        String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt", getClass()), "UTF-8");
 
         assertThat("Always ok if certificate is disabled",
                 getDescriptor().doCheckCaCertificate(false, null).kind, is(OK));
@@ -96,7 +95,6 @@ public class ManagedUpdateSiteJenkinsTest {
     @WebServerRecipe
     public void shouldFailUpdateWithoutCert() throws Exception {
         // Ensure to use server-based download.
-        DownloadSettings.get().setUseBrowser(false);
         TestManagedUpdateSite site = forMethod(jRule.getTestDescription().getMethodName());
 
         jRule.getInstance().getUpdateCenter().getSites().clear();
@@ -115,8 +113,7 @@ public class ManagedUpdateSiteJenkinsTest {
     @WebServerRecipe
     public void shouldSuccessfullyUpdateWithWorkingUC() throws Exception {
         // Ensure to use server-based download.
-        DownloadSettings.get().setUseBrowser(false);
-        String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt", getClass()));
+        String caCertificate = FileUtils.readFileToString(getResource("caCertificate.crt", getClass()), "UTF-8");
 
         TestManagedUpdateSite site = forMethod(jRule.getTestDescription().getMethodName());
 

--- a/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest/testPrivilege/users/admin/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest/testPrivilege/users/admin/config.xml
@@ -4,7 +4,7 @@
   <properties>
     <hudson.security.HudsonPrivateSecurityRealm_-Details>
       <!-- admin -->
-      <passwordHash>jBiboj:4e716bab6438c4947fe4493605b5875c66722630084cda25588c3655049eb984</passwordHash>
+      <passwordHash>#jbcrypt:$2a$10$VVuI8yWPQLf6a8ONRxt7VeW8sgnsToG1isG496VBhMGTFjNn4VAwK</passwordHash>
     </hudson.security.HudsonPrivateSecurityRealm_-Details>
   </properties>
 </user>

--- a/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest/testPrivilege/users/user/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest/testPrivilege/users/user/config.xml
@@ -4,7 +4,7 @@
   <properties>
     <hudson.security.HudsonPrivateSecurityRealm_-Details>
       <!-- user -->
-      <passwordHash>ejHglz:e3ad4146d4ba1b02b2acadd4941db5d966a0c16af3b664852b14d87cc0034c2e</passwordHash>
+      <passwordHash>#jbcrypt:$2a$10$57ielzRQPbrbVdIIMxpX3OQD9XDEWl41zwNUaHYK/pKmD9/I7CSd.</passwordHash>
     </hudson.security.HudsonPrivateSecurityRealm_-Details>
   </properties>
 </user>

--- a/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest/testPrivilege/users/admin/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest/testPrivilege/users/admin/config.xml
@@ -4,7 +4,7 @@
   <properties>
     <hudson.security.HudsonPrivateSecurityRealm_-Details>
       <!-- admin -->
-      <passwordHash>jBiboj:4e716bab6438c4947fe4493605b5875c66722630084cda25588c3655049eb984</passwordHash>
+      <passwordHash>#jbcrypt:$2a$10$VVuI8yWPQLf6a8ONRxt7VeW8sgnsToG1isG496VBhMGTFjNn4VAwK</passwordHash>
     </hudson.security.HudsonPrivateSecurityRealm_-Details>
   </properties>
 </user>

--- a/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest/testPrivilege/users/user/config.xml
+++ b/src/test/resources/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest/testPrivilege/users/user/config.xml
@@ -4,7 +4,7 @@
   <properties>
     <hudson.security.HudsonPrivateSecurityRealm_-Details>
       <!-- user -->
-      <passwordHash>ejHglz:e3ad4146d4ba1b02b2acadd4941db5d966a0c16af3b664852b14d87cc0034c2e</passwordHash>
+      <passwordHash>#jbcrypt:$2a$10$57ielzRQPbrbVdIIMxpX3OQD9XDEWl41zwNUaHYK/pKmD9/I7CSd.</passwordHash>
     </hudson.security.HudsonPrivateSecurityRealm_-Details>
   </properties>
 </user>


### PR DESCRIPTION
Some update center are in intranet where a company can develop own jenkins plugins and publish them on their repository (like artifactory for example). The update site plugin does not handle protected json/hpi that requires authenticated to be downloaded.
This plugin is in use in out production from a couple of years.
The PR also update jenkins version because of credentials plugin. Some APIs are deprecated and some others does not exists anymore (latest impact only test cases)

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue