### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
     <jenkins-test-harness.version>2439.vee0607d480ea_</jenkins-test-harness.version>
   </properties>
 

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/DescribedUpdateSiteJenkinsTest.java
@@ -26,12 +26,13 @@ package jp.ikedam.jenkins.plugins.updatesitesmanager;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.model.UpdateSite;
 import jakarta.annotation.Nonnull;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.html.HtmlForm;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
@@ -96,10 +97,9 @@ class DescribedUpdateSiteJenkinsTest {
         try (JenkinsRule.WebClient wcUser = j.createWebClient()) {
             wcUser.getOptions().setPrintContentOnFailingStatusCode(false);
             wcUser.login("user", "user");
-            ex = Assertions.assertThrows(
-                    FailingHttpStatusCodeException.class, () -> wcUser.goTo(UpdateSitesManager.URL));
+            ex = assertThrows(FailingHttpStatusCodeException.class, () -> wcUser.goTo(UpdateSitesManager.URL));
         }
-        Assertions.assertNotNull(ex);
+        assertNotNull(ex);
         assertThat(ex.getMessage(), containsString("403"));
 
         try (JenkinsRule.WebClient wcAdmin = j.createWebClient()) {
@@ -112,14 +112,13 @@ class DescribedUpdateSiteJenkinsTest {
     }
 
     @Test
-    void shouldErrorOnGetReqOfUpdate(JenkinsRule j) throws Exception {
+    void shouldErrorOnGetReqOfUpdate(JenkinsRule j) {
         Exception ex;
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
             wc.getOptions().setPrintContentOnFailingStatusCode(false);
-            ex = Assertions.assertThrows(
-                    FailingHttpStatusCodeException.class, () -> wc.goTo(UpdateSitesManager.URL + "/update"));
+            ex = assertThrows(FailingHttpStatusCodeException.class, () -> wc.goTo(UpdateSitesManager.URL + "/update"));
         }
-        Assertions.assertNotNull(ex);
+        assertNotNull(ex);
         assertThat(ex.getMessage(), containsString("405"));
     }
 }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/ManagedUpdateSiteJenkinsTest.java
@@ -31,9 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import jp.ikedam.jenkins.plugins.updatesitesmanager.testext.WithUpdateCenterWebServer;
@@ -53,7 +51,7 @@ import org.kohsuke.stapler.HttpResponses;
 class ManagedUpdateSiteJenkinsTest {
 
     @Test
-    void testDescriptorDoCheckCaCertificate(JenkinsRule j) throws IOException, URISyntaxException {
+    void testDescriptorDoCheckCaCertificate(JenkinsRule j) throws Exception {
         String caCertificate =
                 FileUtils.readFileToString(getResource("caCertificate.crt", getClass()), Charset.defaultCharset());
 

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/UpdateSitesManagerJenkinsTest.java
@@ -28,32 +28,29 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.ManagementLink;
 import hudson.model.UpdateSite;
-import java.io.IOException;
 import java.util.List;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.junit.jupiter.WithLocalData;
-import org.xml.sax.SAXException;
 
 /**
  * Tests for UpdateSitesManager, concerned with Jenkins.
  */
 @WithJenkins
-public class UpdateSitesManagerJenkinsTest {
+class UpdateSitesManagerJenkinsTest {
 
     @Test
-    void shouldExistsLinkToManager(JenkinsRule j) throws IOException, SAXException {
+    void shouldExistsLinkToManager(JenkinsRule j) throws Exception {
         try (JenkinsRule.WebClient wc = j.createWebClient()) {
             HtmlPage managementPage = wc.goTo("manage");
 
@@ -70,13 +67,13 @@ public class UpdateSitesManagerJenkinsTest {
 
         UpdateSitesManager manager =
                 j.getInstance().getExtensionList(ManagementLink.class).get(UpdateSitesManager.class);
-        Assertions.assertNotNull(manager);
+        assertNotNull(manager);
         assertThat("managed", manager.getManagedUpdateSiteList(), hasSize(0));
         assertThat("not managed", manager.getNotManagedUpdateSiteList(), hasSize(0));
     }
 
     @Test
-    void shouldReturnBothManagedUnmanaged(JenkinsRule j) throws IOException, SAXException {
+    void shouldReturnBothManagedUnmanaged(JenkinsRule j) {
         UpdateSite site1 = new UpdateSite("test1", "http://example.com/test/update-center.json");
         UpdateSite site2 =
                 new ManagedUpdateSite("test2", "http://example.com/test2/update-center.json", false, null, null, false);
@@ -87,7 +84,7 @@ public class UpdateSitesManagerJenkinsTest {
 
         UpdateSitesManager manager =
                 j.getInstance().getExtensionList(ManagementLink.class).get(UpdateSitesManager.class);
-        Assertions.assertNotNull(manager);
+        assertNotNull(manager);
         assertThat("managed", manager.getManagedUpdateSiteList(), hasSize(1));
         assertThat("not managed", manager.getNotManagedUpdateSiteList(), hasSize(1));
     }
@@ -109,7 +106,7 @@ public class UpdateSitesManagerJenkinsTest {
         List<DescribedUpdateSiteDescriptor> availableDescriptorList = target.getUpdateSiteDescriptorList();
 
         // availableDescriptorList must contain ManagedUpdateSite.
-        Assertions.assertTrue(
+        assertTrue(
                 containsDescriptor(availableDescriptorList, ManagedUpdateSite.class), "ManagedUpdateSite is filtered");
     }
 

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/internal/ExtendedCertJsonSignValidatorTest.java
@@ -1,6 +1,6 @@
 package jp.ikedam.jenkins.plugins.updatesitesmanager.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.util.FormValidation;
 import java.nio.charset.StandardCharsets;
@@ -8,7 +8,6 @@ import java.util.Objects;
 import jenkins.util.JSONSignatureValidator;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -17,7 +16,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
  * @author lanwen (Merkushev Kirill)
  */
 @WithJenkins
-public class ExtendedCertJsonSignValidatorTest {
+class ExtendedCertJsonSignValidatorTest {
 
     @Test
     void shouldAddCustomCertToTrustAnchors(JenkinsRule j) throws Exception {
@@ -32,6 +31,6 @@ public class ExtendedCertJsonSignValidatorTest {
                 Objects.requireNonNull(
                         getClass().getClassLoader().getResourceAsStream(RESOURCE_BASE + "/update-center.json")),
                 StandardCharsets.UTF_8));
-        Assertions.assertEquals(FormValidation.Kind.OK, validator.verifySignature(ucToTest).kind);
+        assertEquals(FormValidation.Kind.OK, validator.verifySignature(ucToTest).kind);
     }
 }

--- a/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/testext/UpdateCenterWebServerExtension.java
+++ b/src/test/java/jp/ikedam/jenkins/plugins/updatesitesmanager/testext/UpdateCenterWebServerExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +31,7 @@ public class UpdateCenterWebServerExtension implements BeforeEachCallback, After
     /**
      * In case of parallel execution of multiply test-methods we can handle server for each method
      */
-    private static final Map<String, String> servers = new HashMap<String, String>();
+    private static final Map<String, String> servers = new HashMap<>();
 
     private Server server;
 
@@ -117,7 +116,7 @@ public class UpdateCenterWebServerExtension implements BeforeEachCallback, After
     private String methodFor(ExtensionContext context) {
         if (context.getTestMethod().isPresent()) {
             Method method = context.getTestMethod().get();
-            Description description = Description.createTestDescription(
+            org.junit.runner.Description description = org.junit.runner.Description.createTestDescription(
                     method.getDeclaringClass(), method.getName(), method.getAnnotations());
             return description.getMethodName();
         }


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed